### PR TITLE
Better understanding of groups

### DIFF
--- a/cmd/interop-entrypoint/Main.hs
+++ b/cmd/interop-entrypoint/Main.hs
@@ -38,7 +38,7 @@ import Crypto.Spake2
   , elementToMessage
   , formatError
   )
-import Crypto.Spake2.Group (Group(..))
+import Crypto.Spake2.Group (AbelianGroup, Group(..))
 import Crypto.Spake2.Groups (Ed25519(..))
 
 
@@ -69,7 +69,7 @@ abort message = do
 
 
 runInteropTest
-  :: (HasCallStack, Group group)
+  :: (HasCallStack, AbelianGroup group)
   => Protocol group SHA256
   -> Password
   -> Handle

--- a/src/Crypto/Spake2.hs
+++ b/src/Crypto/Spake2.hs
@@ -111,7 +111,7 @@ import Data.ByteArray (ByteArrayAccess)
 import qualified Data.ByteArray as ByteArray
 import qualified Data.ByteString as ByteString
 
-import Crypto.Spake2.Group (Group(..), decodeScalar, scalarSizeBytes)
+import Crypto.Spake2.Group (AbelianGroup(..), Group(..), decodeScalar, scalarSizeBytes)
 import qualified Crypto.Spake2.Math as Math
 import Crypto.Spake2.Util (expandData)
 
@@ -132,7 +132,7 @@ makePassword = Password
 newtype SideID = SideID { unSideID :: ByteString } deriving (Eq, Ord, Show)
 
 -- | Convert a user-supplied password into a scalar on a group.
-passwordToScalar :: Group group => group -> Password -> Scalar group
+passwordToScalar :: AbelianGroup group => group -> Password -> Scalar group
 passwordToScalar group password =
   decodeScalar group oversized
   where
@@ -277,7 +277,7 @@ getParams Protocol{group, relation} =
 
 -- | Commence a SPAKE2 exchange.
 startSpake2
-  :: (MonadRandom randomly, Group group)
+  :: (MonadRandom randomly, AbelianGroup group)
   => Protocol group hashAlgorithm
   -> Password
   -> randomly (Math.Spake2Exchange group)

--- a/src/Crypto/Spake2/Groups/Ed25519.hs
+++ b/src/Crypto/Spake2/Groups/Ed25519.hs
@@ -340,7 +340,11 @@ That final check is a Python assertion,
 which would crash the program if incorrect.
 For programming convenience, I just skip these values.
 
-jml doesn't know what is meant by the 'order' of a point.
+The 'order' of a point \(x\( is the number \(n\) such that:
+'scalarMultiply group (integerToScalar group n) x == groupIdentity group'
+
+Note this is different from the order of a /group/,
+which for finite groups is the number of elements in the group.
 
 -}
 

--- a/src/Crypto/Spake2/Groups/Ed25519.hs
+++ b/src/Crypto/Spake2/Groups/Ed25519.hs
@@ -28,7 +28,7 @@ import Data.ByteArray (ByteArray, ByteArrayAccess)
 import qualified Data.ByteArray as ByteArray
 import qualified Data.List as List
 
-import Crypto.Spake2.Group (Group(..), KeyPair(..), scalarSizeBytes)
+import Crypto.Spake2.Group (AbelianGroup(..), Group(..), KeyPair(..), scalarSizeBytes)
 import Crypto.Spake2.Util (bytesToNumber, expandArbitraryElementSeed)
 
 {-
@@ -62,35 +62,40 @@ ideally demonstrating its equivalence with some automated tests.
 data Ed25519 = Ed25519 deriving (Eq, Show)
 
 instance Group Ed25519 where
-  type Scalar Ed25519 = Integer
   type Element Ed25519 = ExtendedPoint 'Member
 
   elementAdd _ x y = addExtendedPoints x y
   elementNegate group = scalarMultiply group (l - 1)
   groupIdentity _ = assertInGroup extendedZero
-  scalarMultiply _ n x = safeScalarMultiply n x
-
-  integerToScalar _ x = x
-  scalarToInteger _ x = x
 
   encodeElement _ x = encodeAffinePoint (extendedToAffine' x)
   decodeElement _ bytes = toCryptoFailable $ do
     extended <- affineToExtended <$> decodeAffinePoint bytes
     ensureInGroup extended
 
-  generateElement group = do
-    scalar <- generateMax l
-    let element = scalarMultiply group scalar generator
-    pure (KeyPair element scalar)
-
   elementSizeBits _ = 255
-  scalarSizeBits _ = 255
 
   arbitraryElement group bytes =
     let seed = expandArbitraryElementSeed bytes (scalarSizeBytes group + 16) :: ByteString
         y = bytesToNumber seed `mod` q
     in
     List.head [ element | Right element <- map makeGroupMember [y..] ]
+
+instance AbelianGroup Ed25519 where
+  type Scalar Ed25519 = Integer
+
+  scalarMultiply _ n x = safeScalarMultiply n x
+
+  integerToScalar _ x = x
+  scalarToInteger _ x = x
+
+  scalarSizeBits _ = 255
+
+  generateElement group = do
+    scalar <- generateMax l
+    let element = scalarMultiply group scalar generator
+    pure (KeyPair element scalar)
+
 
 -- | Errors that can occur within the group.
 data Error

--- a/src/Crypto/Spake2/Groups/Ed25519.hs
+++ b/src/Crypto/Spake2/Groups/Ed25519.hs
@@ -340,7 +340,7 @@ That final check is a Python assertion,
 which would crash the program if incorrect.
 For programming convenience, I just skip these values.
 
-The 'order' of a point \(x\( is the number \(n\) such that:
+The 'order' of a point \(x\) is the number \(n\) such that:
 'scalarMultiply group (integerToScalar group n) x == groupIdentity group'
 
 Note this is different from the order of a /group/,

--- a/src/Crypto/Spake2/Math.hs
+++ b/src/Crypto/Spake2/Math.hs
@@ -103,7 +103,7 @@ import Protolude hiding (group)
 
 import Crypto.Random.Types (MonadRandom(..))
 
-import Crypto.Spake2.Group (Group(..), KeyPair(..))
+import Crypto.Spake2.Group (AbelianGroup(..), Group(..), KeyPair(..))
 
 -- | The parameters of the SPAKE2 protocol. The other side needs to be using
 -- the same values, but with swapped values for 'ourBlind' and 'theirBlind'.
@@ -135,11 +135,11 @@ data Spake2Exchange group
 
 -- | Initiate the SPAKE2 exchange. Generates a secret (@xy@) that will be held
 -- by this side, and transmitted to the other side in "blinded" form.
-startSpake2 :: (Group group, MonadRandom randomly) => Spake2 group -> randomly (Spake2Exchange group)
+startSpake2 :: (AbelianGroup group, MonadRandom randomly) => Spake2 group -> randomly (Spake2Exchange group)
 startSpake2 spake2' = Started spake2' <$> generateElement (group . params $ spake2')
 
 -- | Determine the element (either \(X^{\star}\) or \(Y^{\star}\)) to send to the other side.
-computeOutboundMessage :: Group group => Spake2Exchange group -> Element group
+computeOutboundMessage :: AbelianGroup group => Spake2Exchange group -> Element group
 computeOutboundMessage Started{spake2 = Spake2{params = Params{group, ourBlind}, password}, xy} =
   elementAdd group (keyPairPublic xy) (scalarMultiply group password ourBlind)
 
@@ -161,7 +161,7 @@ computeOutboundMessage Started{spake2 = Spake2{params = Params{group, ourBlind},
 -- * \(K\) is the result of this function
 -- * \(pw\) is the password (this is what makes it SPAKE2, not SPAKE1)
 generateKeyMaterial
-  :: Group group
+  :: AbelianGroup group
   => Spake2Exchange group  -- ^ An initiated SPAKE2 exchange
   -> Element group  -- ^ The outbound message from the other side (i.e. inbound to us)
   -> Element group -- ^ The final piece of key material to generate the session key.

--- a/tests/Groups.hs
+++ b/tests/Groups.hs
@@ -33,7 +33,7 @@ groupProperties
   -> Spec
 groupProperties group elements = do
   it "addition is associative" $ property $
-    forAll triples $ \(x, y, z) -> elementAdd group (elementAdd group x y) z === elementAdd group x (elementAdd group y z)
+    forAll (triples elements) $ \(x, y, z) -> elementAdd group (elementAdd group x y) z === elementAdd group x (elementAdd group y z)
 
   it "addition with inverse yields identity" $ property $
     forAll elements $ \x -> elementAdd group x (elementNegate group x) === groupIdentity group
@@ -45,7 +45,7 @@ groupProperties group elements = do
     elementNegate group (groupIdentity group) `shouldBe` groupIdentity group
 
   it "subtraction is negated addition" $ property $
-    forAll pairs $ \(x, y) -> elementSubtract group x y === elementAdd group x (elementNegate group y)
+    forAll (pairs elements) $ \(x, y) -> elementSubtract group x y === elementAdd group x (elementNegate group y)
 
   it "right-hand addition with identity yields original" $ property $
     forAll elements $ \x -> elementAdd group x (groupIdentity group) === x
@@ -57,18 +57,6 @@ groupProperties group elements = do
     forAll elements $ \x -> let bytes = encodeElement group x :: ByteString
                             in decodeElement group bytes == CryptoPassed x
 
-  where
-    pairs = do
-      x <- elements
-      y <- elements
-      pure (x, y)
-
-    triples = do
-      x <- elements
-      y <- elements
-      z <- elements
-      pure (x, y, z)
-
 
 abelianGroupProperties
   :: (AbelianGroup group, Eq (Element group), Eq (Scalar group), Show (Element group), Show (Scalar group))
@@ -78,7 +66,7 @@ abelianGroupProperties
   -> Spec
 abelianGroupProperties group base scalars = do
   it "addition is commutative" $ property $
-    forAll pairs $ \(x, y) -> elementAdd group x y === elementAdd group y x
+    forAll (pairs elements) $ \(x, y) -> elementAdd group x y === elementAdd group y x
 
   it "scalar to integer roundtrips" $ property $
     forAll scalars $ \n -> integerToScalar group (scalarToInteger group n) === n
@@ -101,11 +89,20 @@ abelianGroupProperties group base scalars = do
   where
     elements = makeElement group scalars base
 
-    pairs = do
-      x <- elements
-      y <- elements
-      pure (x, y)
+-- | Generate pairs of a thing.
+pairs :: Gen a -> Gen (a, a)
+pairs gen = do
+  x <- gen
+  y <- gen
+  pure (x, y)
 
+-- | Generate triples of a thing.
+triples :: Gen a -> Gen (a, a, a)
+triples gen = do
+  x <- gen
+  y <- gen
+  z <- gen
+  pure (x, y, z)
 
 makeScalar :: Integer -> Gen Integer
 makeScalar k = do

--- a/tests/Groups.hs
+++ b/tests/Groups.hs
@@ -32,7 +32,7 @@ allGroupProperties
   -> Spec
 allGroupProperties group scalars base = do
   describe "is a group" $ groupProperties group (makeElement group scalars base)
-  describe "is an abelian group" $ abelianGroupProperties group base scalars
+  describe "is an abelian group" $ abelianGroupProperties group scalars base
 
 groupProperties
   :: (Group group, Eq (Element group), Show (Element group))
@@ -69,10 +69,10 @@ groupProperties group elements = do
 abelianGroupProperties
   :: (AbelianGroup group, Eq (Element group), Eq (Scalar group), Show (Element group), Show (Scalar group))
   => group
-  -> Element group
   -> Gen (Scalar group)
+  -> Element group
   -> Spec
-abelianGroupProperties group base scalars = do
+abelianGroupProperties group scalars base = do
   it "addition is commutative" $ property $
     forAll (pairs elements) $ \(x, y) -> elementAdd group x y === elementAdd group y x
 

--- a/tests/Groups.hs
+++ b/tests/Groups.hs
@@ -26,17 +26,6 @@ tests = testSpec "Groups" $ do
     describe "is a group" $ groupProperties Ed25519 (makeElement Ed25519 (makeScalar Ed25519.l) Ed25519.generator)
     describe "is an abelian group" $ abelianGroupProperties Ed25519 Ed25519.generator (makeScalar Ed25519.l)
 
-
-makeScalar :: Integer -> Gen Integer
-makeScalar k = do
-  i <- arbitrary
-  pure $ i `mod` k
-
-makeElement :: AbelianGroup group => group -> Gen (Scalar group) -> Element group -> Gen (Element group)
-makeElement group scalars base = do
-  scalar <- scalars
-  pure (scalarMultiply group scalar base)
-
 groupProperties
   :: (Group group, Eq (Element group), Show (Element group))
   => group
@@ -116,3 +105,14 @@ abelianGroupProperties group base scalars = do
       x <- elements
       y <- elements
       pure (x, y)
+
+
+makeScalar :: Integer -> Gen Integer
+makeScalar k = do
+  i <- arbitrary
+  pure $ i `mod` k
+
+makeElement :: AbelianGroup group => group -> Gen (Scalar group) -> Element group -> Gen (Element group)
+makeElement group scalars base = do
+  scalar <- scalars
+  pure (scalarMultiply group scalar base)

--- a/tests/Groups.hs
+++ b/tests/Groups.hs
@@ -19,12 +19,20 @@ import qualified Crypto.Spake2.Groups.IntegerGroup as IntegerGroup
 
 tests :: IO TestTree
 tests = testSpec "Groups" $ do
-  describe "integer group" $ do
-    describe "is a group" $ groupProperties i1024 (makeElement i1024 (makeScalar (subgroupOrder i1024)) (IntegerGroup.generator i1024))
-    describe "is an abelian group" $ abelianGroupProperties i1024 (IntegerGroup.generator i1024) (makeScalar (subgroupOrder i1024))
-  describe "Ed25519" $ do
-    describe "is a group" $ groupProperties Ed25519 (makeElement Ed25519 (makeScalar Ed25519.l) Ed25519.generator)
-    describe "is an abelian group" $ abelianGroupProperties Ed25519 Ed25519.generator (makeScalar Ed25519.l)
+  describe "integer group" $
+    allGroupProperties i1024 (makeScalar (subgroupOrder i1024)) (IntegerGroup.generator i1024)
+  describe "Ed25519" $
+    allGroupProperties Ed25519 (makeScalar Ed25519.l) Ed25519.generator
+
+allGroupProperties
+  :: (Show (Scalar group), Show (Element group), Eq (Scalar group), Eq (Element group), AbelianGroup group)
+  => group
+  -> Gen (Scalar group)
+  -> Element group
+  -> Spec
+allGroupProperties group scalars base = do
+  describe "is a group" $ groupProperties group (makeElement group scalars base)
+  describe "is an abelian group" $ abelianGroupProperties group base scalars
 
 groupProperties
   :: (Group group, Eq (Element group), Show (Element group))


### PR DESCRIPTION
I woke up at 3:30am, so I had a little more time than usual to get stuff done this morning.

I did a bunch of reading on Wikipedia (which I really should link to from the code itself) and figured out how scalar multiplication relates to groups. 

Although we don't *need* to do this to make the library useful, I figure this new understanding should be built into the code itself.

I don't feel I yet have a complete understanding, but this is certainly closer to the truth than what's in master.

For reviewing, I'd suggest looking at each commit separately, since the initial commit triggered a bunch of natural refactorings.

Code-wise, the big change is taking the `Group` typeclass (think of it like an interface) and splitting it into two typeclasses: `Group` and `AbelianGroup`. `AbelianGroup` extends `Group`, which means that the type checker enforces that anything which implements `AbelianGroup` must also implement `Group`.

For me, the insight here is that scalars really aren't a group thing, they are only a thing that you can choose to add on to abelian groups. This notion of group + scalar is called a 'module', but I really didn't want to use that name in code because a) it means something very different in Haskell & Python; b) I feel we have enough terminology. See the "Algebra" note for more information.

This split in turn compels the various implementations of the original `Group` typeclass to be split. This is pretty boring.

Following this, it makes sense for the tests to distinguish between properties that are relevant for any group and properties that only matter for abelian groups.

This in turn means that we don't need to generate scalars in the vanilla group tests, so we don't have to pass a generator through as an argument.

Once that's all sorted, a bunch of small refactorings naturally present themselves, which I've tried to do each as separate commits.