### PR TITLE
Remove unproven shortcut from safeScalarMultiply

### DIFF
--- a/src/Crypto/Spake2/Groups/Ed25519.hs
+++ b/src/Crypto/Spake2/Groups/Ed25519.hs
@@ -301,7 +301,6 @@ safeScalarMultiply n = scalarMultiplyExtendedPoint addExtendedPoints n
 scalarMultiplyExtendedPoint :: (ExtendedPoint a -> ExtendedPoint a -> ExtendedPoint a) -> Integer -> ExtendedPoint a -> ExtendedPoint a
 scalarMultiplyExtendedPoint _ 0 _    = extendedZero
 scalarMultiplyExtendedPoint add n x
-  | n >= l    = scalarMultiplyExtendedPoint add (n `mod` l) x
   | even n    = doubleExtendedPoint (scalarMultiplyExtendedPoint add (n `div` 2) x)
   | n == 1    = x
   | n <= 0    = panic $ "Unexpected negative multiplier: " <> show n

--- a/src/Crypto/Spake2/Groups/Ed25519.hs
+++ b/src/Crypto/Spake2/Groups/Ed25519.hs
@@ -18,7 +18,7 @@ module Crypto.Spake2.Groups.Ed25519
   , generator
   ) where
 
-import Protolude hiding (group, zero)
+import Protolude hiding (group)
 
 import Crypto.Error (CryptoFailable(..), CryptoError(..))
 import Crypto.Number.Generate (generateMax)


### PR DESCRIPTION
Makes `ensureInGroup` behaviour conform better to Python implementation.

@ocheron care to take a look?