### PR TITLE
type annotation to help ghc 8.4.2 to resolve the IsString constraint

### DIFF
--- a/cmd/interop-entrypoint/Main.hs
+++ b/cmd/interop-entrypoint/Main.hs
@@ -1,4 +1,5 @@
 {-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE TypeApplications #-}
 -- | Entrypoint for testing interoperability.
 --
 -- Interoperability harness lives at <https://github.com/leastauthority/spake2-interop-test>
@@ -19,6 +20,7 @@ import Protolude hiding (group)
 
 import Crypto.Hash (SHA256(..))
 import Data.ByteArray.Encoding (convertFromBase, convertToBase, Base(Base16))
+import Data.String (String)
 import Options.Applicative
 import System.IO (hFlush, hGetLine)
 
@@ -52,8 +54,7 @@ configParser =
         "B" -> pure SideB
         "Symmetric" -> pure Symmetric
         unknown -> throwError $ "Unrecognized side: " <> unknown
-    passwordParser = makePassword . toS <$> (str :: ReadM Text)
-
+    passwordParser = makePassword . toS @String <$> str
 
 -- | Terminate the test with a failure, printing a message to stderr.
 abort :: HasCallStack => Text -> IO ()

--- a/cmd/interop-entrypoint/Main.hs
+++ b/cmd/interop-entrypoint/Main.hs
@@ -52,7 +52,7 @@ configParser =
         "B" -> pure SideB
         "Symmetric" -> pure Symmetric
         unknown -> throwError $ "Unrecognized side: " <> unknown
-    passwordParser = makePassword . toS <$> str
+    passwordParser = makePassword . toS <$> (str :: ReadM Text)
 
 
 -- | Terminate the test with a failure, printing a message to stderr.


### PR DESCRIPTION
Compiling with ghc 8.4.2 results in the following type error:

```
cmd/interop-entrypoint/Main.hs:56:37: error:
    • Ambiguous type variable ‘a0’ arising from a use of ‘toS’
      prevents the constraint ‘(StringConv
                                  a0 ByteString)’ from being solved.
      Probable fix: use a type annotation to specify what ‘a0’ should be.
      These potential instances exist:
        instance StringConv ByteString ByteString
          -- Defined in ‘Protolude.Conv’
        instance StringConv Text ByteString -- Defined in ‘Protolude.Conv’
        instance StringConv GHC.Base.String ByteString
          -- Defined in ‘Protolude.Conv’
        ...plus two instances involving out-of-scope types
        (use -fprint-potential-instances to see them all)
    • In the second argument of ‘(.)’, namely ‘toS’
      In the first argument of ‘(<$>)’, namely ‘makePassword . toS’
      In the expression: makePassword . toS <$> str
   |
56 |     passwordParser = makePassword . toS <$> str
   |                                     ^^^

cmd/interop-entrypoint/Main.hs:56:45: error:
    • Ambiguous type variable ‘a0’ arising from a use of ‘str’
      prevents the constraint ‘(IsString a0)’ from being solved.
      Probable fix: use a type annotation to specify what ‘a0’ should be.
      These potential instances exist:
        instance IsString a => IsString (Identity a)
          -- Defined in ‘Data.String’
        instance IsString ByteString
          -- Defined in ‘bytestring-0.10.8.2:Data.ByteString.Internal’
        instance (a ~ Char) => IsString (Seq a)
          -- Defined in ‘containers-0.5.11.0:Data.Sequence.Internal’
        ...plus two others
        ...plus five instances involving out-of-scope types
        (use -fprint-potential-instances to see them all)
    • In the second argument of ‘(<$>)’, namely ‘str’
      In the expression: makePassword . toS <$> str
      In an equation for ‘passwordParser’:
          passwordParser = makePassword . toS <$> str
   |
56 |     passwordParser = makePassword . toS <$> str
```
The commit adds a type annotation to help resolve the type.